### PR TITLE
Fix behavior with single quotes or leading hyphens

### DIFF
--- a/tmux-text-macros.tmux
+++ b/tmux-text-macros.tmux
@@ -34,9 +34,10 @@ tmux_macros() {
         fi
         all=("${alldefaults[@]}" "${custom[@]}")
 
-        for e in "${all[@]}"; do
+        tosend="$(for e in "${all[@]}"; do
             echo $e
-        done|fzf|sed -e 's/\\/\\\\/g' -e 's/\(.*\):.*/\1/'|xargs -I_ tmux send-keys -t "$PANE" '_'
+        done|fzf|sed -e 's/\\/\\\\/g' -e 's/\(.*\):.*/\1/')"
+        tmux send-keys -t "$PANE" -l "" "$tosend"
     else
         if [ "$window_mode" = "vertical" ];then
             command="tmux split-window -v"


### PR DESCRIPTION
I wanted to use this tool to type out shortcuts for commands, but found that due to `xargs` stripping single quotes, I couldn't put quotes in my macros, and if it lead with a hyphen, that would be interpreted as part of the send-keys command. This address both of these issues. It uses a local var, which might not be ideal, but it works for me.

Try it out with the following:
```
custom=(
"docker logs -f \$(docker ps | awk 'NR>1 {print \$1}'): Docker log"
'--long-parameter-name : Parameter'
)
```