### PR TITLE
Fix emoji with multiple colons in description 👨🏽‍💻

### DIFF
--- a/tmux-text-macros.tmux
+++ b/tmux-text-macros.tmux
@@ -12,7 +12,7 @@ get_tmux_option() {
 tmux_macros() {
     if [ "$1" = "-r" ];then
         set -f
-        #Macro strings. Everything after the last ":" gets removed and is just there as a search string in fzf
+        #Macro strings. The first ":" and everything after gets removed and is just there as a search string in fzf
         local BASEDIR=$(dirname $0)
 
         custom=()
@@ -36,7 +36,7 @@ tmux_macros() {
 
         tosend="$(for e in "${all[@]}"; do
             echo $e
-        done|fzf|sed -e 's/\(.*\):.*/\1/')"
+        done|fzf|sed -e 's/\([^:]*\):.*/\1/')"
         tmux send-keys -t "$PANE" -l "" "$tosend"
     else
         if [ "$window_mode" = "vertical" ];then


### PR DESCRIPTION
Many emoji descriptions in emoji.json contain multiple colons.

For example:

```
'💪🏽: flexed biceps: medium skin tone [People & Body (body-parts)]'
```
```
'🇺🇸: flag: United States [Flags (country-flag)]'
```

When inserting these emoji, some of the description text gets inserted
along with the emoji because the greedy sed regex grabs text until the
last colon.

Tweaking the sed regex to only grab text until the _first_ colon fixes
that issue.

I tested this with a random sampling of emoji with one or more colons in
the description, including the one in the commit message.